### PR TITLE
Support for Include Directive in SSH Config

### DIFF
--- a/src/hostdesc.h
+++ b/src/hostdesc.h
@@ -18,10 +18,18 @@ public:
     int port_ = 22;
     bool is_ipv6_literal_ = false;
     vector<string> identity_files_;
+    bool hostname_set = false;
+    bool identityfile_set = false;
+    bool username_given = false;
+    bool user_set = false;
+    bool port_given = false;
+    bool port_set = false;
 
     HostDesc() {}
 
     explicit HostDesc(string host, string identity_file);
+
+    void ParseConfigFile(string path);
 
     string ToString();
 


### PR DESCRIPTION
# Pull Request Description
This pull request adds support for the `Include` directive in the SSH configuration file (~/.ssh/config). 
The Include directive allows users to reference additional configuration files, enabling modular and organized SSH configurations.

For example you could have in `~/.ssh/config`:
```bash
Include config.d/home

Host github.com
    HostName github.com
    User git
```

and in `~/.ssh/config.d/home`:

```bash
Host laptop
    HostName laptop.lan
```
